### PR TITLE
docs: mark archived MCP ADR accepted

### DIFF
--- a/docs/adr/ADR-4-mcp-family-sota-roadmap.md
+++ b/docs/adr/ADR-4-mcp-family-sota-roadmap.md
@@ -1,7 +1,7 @@
 # ADR-4: Adopt RAG Server MCP Retirement Roadmap
 
 Date: 2026-07-09
-Status: Proposed in PR #4
+Status: Accepted
 Slug: mcp-family-sota-roadmap
 
 ## Context


### PR DESCRIPTION
## Summary
- mark the merged archived MCP family ADR as accepted
- remove stale proposed-state wording while preserving archive handoff intent

## Validation
- git diff --check